### PR TITLE
Fix required key in validation objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### v NEXT
 
+### v 0.0.4
+- Fix required option for validation objects [#4](https://github.com/policygenius/redux-form-validations/pull/4)
+
 ### v 0.0.3
 - Do not throw errors when isBeforeDate value is not a valid date [Jeremy Danziger](https://github.com/jdanz)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-validations",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Validation utilities for redux-form v6",
   "author": "PolicyGenius",
   "license": "MIT",

--- a/src/buildValidations.js
+++ b/src/buildValidations.js
@@ -1,4 +1,5 @@
 import { pickBy, get, startCase, forEach } from 'lodash';
+import isPresent from './validators/isPresent';
 
 const labelFor = (schema, fieldName) => schema[fieldName].label || startCase(fieldName);
 
@@ -17,7 +18,7 @@ const buildValidators = (schema, type) => (values) => {
     const validateCondition = schema[field][type].validateIf;
     const isRequired = schema[field][type].required;
 
-    if (isRequired) {
+    if (isRequired && !isPresent.validator(values, values[field])) {
       errors[field] = 'Required';
     } else if (!validateCondition || validateCondition(values, values[field])) {
       if (!schema[field][type].validator(values, values[field])) {

--- a/src/buildValidations.spec.js
+++ b/src/buildValidations.spec.js
@@ -113,11 +113,34 @@ describe('buildErrors', () => {
           },
         },
       };
-      const values = { someEmail: null };
 
-      it('returns an error that the field is required', () => {
-        expect(buildValidations(schema).validate(values)).toEqual({
-          someEmail: 'Required',
+      context('and the field value is not present', () => {
+        const values = { someEmail: null };
+
+        it('returns an error that the field is required', () => {
+          expect(buildValidations(schema).validate(values)).toEqual({
+            someEmail: 'Required',
+          });
+        });
+      });
+
+      context('and the field value is not present', () => {
+        context('and the field is valid', () => {
+          const values = { someEmail: 'email@foo.com' };
+
+          it('does not return an error', () => {
+            expect(buildValidations(schema).validate(values)).toEqual({});
+          });
+        });
+      });
+
+      context('and the field is not valid', () => {
+        const values = { someEmail: 'not an email' };
+
+        it('returns the error message for the validator', () => {
+          expect(buildValidations(schema).validate(values)).toEqual({
+            someEmail: 'Must be a valid email',
+          });
         });
       });
     });


### PR DESCRIPTION
Previously the `required` key in a validator object was always returning errors, whether the value was present or not. Now returns 'Required' error only if not present, else follows main validation rules.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the public API, update the README
