### PR TITLE
Add support for dynamic error messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### v NEXT
 
+### v 0.0.8
+Add dynamic error messages by [Justin Schulz](https://github.com/PepperTeasdale) in [#11](https://github.com/policygenius/redux-form-validations/pull/11)
+
 ### v 0.0.7
 - Fix exporting `.isDateBefore()` validator by [Trevor Nelson](https://github.com/trevornelson) in [#8](https://github.com/policygenius/redux-form-validations/pull/8)
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ class MyForm extends React.Component { ... }
 export default reduxForm({ warn, validate })(MyForm);
 ```
 
+## Custom validators
+
+Every field defined in your schema object has top-level keys `warn` and `validate` which are used to build warn and validate functions for redux-form connected components. These keys take a _validator object_, which has the shape:
+
+`validator`: Function (allFields, value) => Boolean
+If the return value is true, then the field is valid, if false, an error is added.
+`errorMessage`: String || Function (allField, value) => String
+The error message that is returned with the `validate` or `warn` function call when the `validator` returns false.
+
 ## Prior work
 [redux-form-schema](https://github.com/Lighthouse-io/redux-form-schema) is the main
 inspiration for this project. After redux-form moved to V6, this project was deprecated,

--- a/src/buildValidations.js
+++ b/src/buildValidations.js
@@ -3,8 +3,11 @@ import isPresent from './validators/isPresent';
 
 const labelFor = (schema, fieldName) => schema[fieldName].label || startCase(fieldName);
 
-const errorMessageFor = ({ schema, fieldName, errors, rule }) => {
+const errorMessageFor = ({ schema, fieldName, errors, rule, values }) => {
   if (get(rule, 'errorMessage') && !errors[fieldName]) {
+    if (typeof rule.errorMessage === 'function') {
+      return rule.errorMessage(values, values[fieldName]);
+    }
     return rule.errorMessage;
   }
   return `${labelFor(schema, fieldName)} is not valid`;
@@ -34,7 +37,7 @@ const buildValidators = (schema, type) => (values) => {
       if (requiredAndNotPresent) {
         errors[field] = 'Required';
       } else if (!valid) {
-        errors[field] = errorMessageFor({ schema, fieldName: field, errors, rule });
+        errors[field] = errorMessageFor({ schema, fieldName: field, errors, rule, values });
       }
     } else {
       const rules = schema[field][type];
@@ -46,7 +49,7 @@ const buildValidators = (schema, type) => (values) => {
         if (requiredAndNotPresent) {
           errors[field] = 'Required';
         } else if (!valid) {
-          errors[field] = errorMessageFor({ schema, fieldName: field, errors, rule });
+          errors[field] = errorMessageFor({ schema, fieldName: field, errors, rule, values });
         }
       },
       );

--- a/src/buildValidations.spec.js
+++ b/src/buildValidations.spec.js
@@ -41,29 +41,54 @@ describe('buildErrors', () => {
     });
 
     context('when the error message is specified', () => {
-      const schema = {
-        requiredWithMessage: {
-          validate: {
-            errorMessage: 'Required sucka foo!',
-            validator: isPresent.validator,
+      context('when the error message is a string', () => {
+        const schema = {
+          requiredWithMessage: {
+            validate: {
+              errorMessage: 'Required sucka foo!',
+              validator: isPresent.validator,
+            },
           },
-        },
-        undefinedRequired: {
-          validate: {
-            validator: isPresent.validator,
+          undefinedRequired: {
+            validate: {
+              validator: isPresent.validator,
+            },
           },
-        },
-      };
+        };
 
-      const values = { requiredWithMessage: '', undefinedRequired: undefined };
+        const values = { requiredWithMessage: '', undefinedRequired: undefined };
 
-      it('returns an object with custom error messages', () => {
-        expect(buildValidations(schema).validate(values)).toEqual(
-          {
-            requiredWithMessage: 'Required sucka foo!',
-            undefinedRequired: 'Undefined Required is not valid',
+        it('returns an object with custom error messages', () => {
+          expect(buildValidations(schema).validate(values)).toEqual(
+            {
+              requiredWithMessage: 'Required sucka foo!',
+              undefinedRequired: 'Undefined Required is not valid',
+            },
+          );
+        });
+      });
+
+      context('when the error message is a function', () => {
+        const schema = {
+          requiredWithDynamicMessage: {
+            validate: {
+              errorMessage: (allFields, field) => {
+                const fieldNames = Object.keys(allFields).join(', ');
+                return `All fields are ${fieldNames} and the value is ${field}`;
+              },
+              validator: () => false,
+            },
           },
-        );
+          otherField: {},
+        };
+
+        const values = { requiredWithDynamicMessage: 'foo', otherField: 'bar' };
+
+        it('returns an object with dynamic error messages', () => {
+          expect(buildValidations(schema).validate(values)).toEqual({
+            requiredWithDynamicMessage: 'All fields are requiredWithDynamicMessage, otherField and the value is foo',
+          });
+        });
       });
     });
 


### PR DESCRIPTION
The `errorMessage` key can now take a function or a string. The function has the same arguments as the validator function, but returns a string rather than a boolean.

<!--
  Thanks for filing a pull request on redux-form-validations!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the public API, update the README
