### PR TITLE
Add ability to construct validate from props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": "policygenius",
+  "env": {
+    "jest": true
+  },
   "globals": {
     "expect": false
   },

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: node_js
 node_js:
+  - "8"
   - "7"
   - "6"
   - "5"
 
 install:
-  - npm install
+  - yarn install
 
 script:
-  - npm test
+  - yarn test
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### v NEXT
 
+### v 0.1.0
+Add ability to construct field validate property as a function that receives props [John Colella](https://github.com/jmcolella) in [#17](https://github.com/policygenius/redux-form-validations/pull/17)
+
 ### v 0.0.11
 Simplify email validation regex [James Lowenthal](https://github.com/JamesAnthonyLow) in [#16](https://github.com/policygenius/redux-form-validations/pull/16)
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ If the return value is true, then the field is valid, if false, an error is adde
 `errorMessage`: String || Function (allField, value) => String
 The error message that is returned with the `validate` or `warn` function call when the `validator` returns false.
 
+Alternatively, you can assign a function that returns a _validator object_ to either `warn` or `validate` that will receive `props` from your ReduxForm wrapped component. This is helpful if you need to validate based on information outside of the form state.
+
+Example:
+
+```javascript
+const { warn, validate } = buildValidations({
+  firstName: {
+    validate: (props) => ({
+      validator: (fields) => {
+        return props.someBoolean && fields.numbers > 0,
+      }
+    }),
+  },
+});
+```
+
 ## Prior work
 [redux-form-schema](https://github.com/Lighthouse-io/redux-form-schema) is the main
 inspiration for this project. After redux-form moved to V6, this project was deprecated,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-validations",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "description": "Validation utilities for redux-form v6",
   "author": "PolicyGenius",
   "license": "MIT",

--- a/src/buildValidations.js
+++ b/src/buildValidations.js
@@ -28,13 +28,19 @@ const isValid = ({ values, field, rule }) => {
   return true;
 };
 
-const buildValidators = (schema, type) => (values) => {
+const buildValidators = (schema, type) => (values, props) => {
   const errors = {};
   const validatedFields = Object.keys(pickBy(schema, obj => get(obj, type)));
 
   forEach(validatedFields, (field) => {
-    if (!isArray(schema[field][type])) {
-      const rule = schema[field][type];
+    let validation = schema[field][type];
+
+    if (typeof validation === 'function') {
+      validation = validation(props);
+    }
+
+    if (!isArray(validation)) {
+      const rule = validation;
       const requiredAndNotPresent = isRequiredAndNotPresent({ values, field, rule });
       const valid = isValid({ values, field, rule });
 
@@ -44,7 +50,7 @@ const buildValidators = (schema, type) => (values) => {
         errors[field] = errorMessageFor({ schema, fieldName: field, errors, rule, values });
       }
     } else {
-      const rules = schema[field][type];
+      const rules = validation;
 
       forEach(rules, (rule) => {
         const requiredAndNotPresent = isRequiredAndNotPresent({ values, field, rule });

--- a/src/buildValidations.spec.js
+++ b/src/buildValidations.spec.js
@@ -462,6 +462,57 @@ describe('buildErrors', () => {
     });
   });
 
+  context('schema has validate functions', () => {
+    context('when there are required fields', () => {
+      context('when there are no specified error messages', () => {
+        const mockValidate = jest.fn().mockReturnValue({
+          validator: isPresent.validator,
+        });
+
+        const schema = {
+          someRequired: {
+            validate: isPresent,
+          },
+          anotherRequired: {
+            validate: mockValidate,
+          },
+          blankRequired: {
+            validate: {
+              validator: isPresent.validator,
+            },
+          },
+          nawNotRequired: {},
+        };
+
+        const values = {
+          someRequired: 'and it is there',
+          anotherRequired: null,
+          blankRequired: '',
+          nawNotRequired: null,
+        };
+
+        const props = {
+          some: 'props',
+        };
+
+        it('calls the validate function with props', () => {
+          buildValidations(schema).validate(values, props);
+
+          expect(mockValidate).toHaveBeenCalledWith(props);
+        });
+
+        it('returns an object with default field error messages', () => {
+          expect(buildValidations(schema).validate(values)).toEqual(
+            {
+              anotherRequired: 'Another Required is not valid',
+              blankRequired: 'Blank Required is not valid',
+            },
+          );
+        });
+      });
+    });
+  });
+
   context('when there are warn fields', () => {
     context('when top level', () => {
       const schema = {


### PR DESCRIPTION
@jdanz @samanthavholmes @trevornelson CR please

Adds ability to construct the `validate` property for a field as a function that receives `props` from the ReduxForm wrapped form. This is helpful for building validations that may rely on information not found in the form state.

TODO:

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests pass
- [X] Update CHANGELOG.md with your change
- [X] If this was a change that affects the public API, update the README
