### PR TITLE
Add isDateOnOrAfter validator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015", "stage-0", "minify-es2015"],
+  "presets": ["minify-es2015", "stage-0", "es2015"],
   "plugins": ["babel-plugin-transform-runtime"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### v NEXT
 
+### v 0.1.1
+Add isDateOnOrAfter validator by [John Colella](https://github.com/jmcolella) in [#18](https://github.com/policygenius/redux-form-validations/pull/6)
+
 ### v 0.1.0
 Add ability to construct field validate property as a function that receives props [John Colella](https://github.com/jmcolella) in [#17](https://github.com/policygenius/redux-form-validations/pull/17)
 

--- a/src/validators/isDateOnOrAfter.js
+++ b/src/validators/isDateOnOrAfter.js
@@ -1,0 +1,9 @@
+import isNil from 'lodash/isNil';
+import format from 'date-fns/format';
+import isAfter from 'date-fns/is_after';
+import isEqual from 'date-fns/is_equal';
+
+export default date => ({
+  errorMessage: `Must be on or after ${format(date, 'MMMM Do YYYY')}`,
+  validator: (allValues, value) => (isNil(value) || isAfter(value, date) || isEqual(value, date)),
+});

--- a/src/validators/isDateOnOrAfter.spec.js
+++ b/src/validators/isDateOnOrAfter.spec.js
@@ -1,0 +1,40 @@
+import isDateOnOrAfter from './isDateOnOrAfter';
+
+describe('isDateOnOrAfter', () => {
+  const someFields = {};
+  const validationDate = '2/16/2017';
+
+  context('when the value is a parsable date', () => {
+    context('and that date is before the validation date', () => {
+      it('returns false', () => {
+        expect(isDateOnOrAfter(validationDate).validator(someFields, '2/15/2017')).toBe(false);
+      });
+    });
+
+    context('and that date is on the validation date', () => {
+      it('returns false', () => {
+        expect(isDateOnOrAfter(validationDate).validator(someFields, '2/16/2017')).toBe(true);
+      });
+    });
+
+    context('and that date is after the validation date', () => {
+      it('returns true', () => {
+        expect(isDateOnOrAfter(validationDate).validator(someFields, '2/17/2017')).toBe(true);
+      });
+    });
+  });
+
+  context('when the value is not a parsable date', () => {
+    context('and the value is nil', () => {
+      it('returns true', () => {
+        expect(isDateOnOrAfter(validationDate).validator(someFields, null)).toBe(true);
+      });
+    });
+
+    context('and the value is not a valid date format', () => {
+      it('returns false', () => {
+        expect(isDateOnOrAfter(validationDate).validator(someFields, 'two/seventeen/twothousandseventeen')).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
@jdanz @samanthavholmes @trevornelson CR please

- Adds `isDateOnOrAfter` validator to allow for validating date fields that are inclusive of the start date.

TODO:

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests pass
- [X] Update CHANGELOG.md with your change
