### PR TITLE
Add export for isDateOnOrAfter to index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### v NEXT
 
+### v 0.1.2
+- Fix exporting `.isDateOnOrAfter()` validator by [John Colella](https://github.com/jmcolella) in [#20](https://github.com/policygenius/redux-form-validations/pull/20)
+
 ### v 0.1.1
 Add isDateOnOrAfter validator by [John Colella](https://github.com/jmcolella) in [#18](https://github.com/policygenius/redux-form-validations/pull/6)
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ export isDateAfter from './validators/isDateAfter';
 export isEmail from './validators/isEmail';
 export isPresent from './validators/isPresent';
 export isZipCode from './validators/isZipCode';
+export isDateOnOrAfter from './validators/isDateOnOrAfter';

--- a/src/validators/isBetween.spec.js
+++ b/src/validators/isBetween.spec.js
@@ -1,4 +1,4 @@
-import isBetween from './isBetween';
+import { isBetween } from '../';
 
 describe('isBetween', () => {
   const someFields = {};

--- a/src/validators/isDateAfter.spec.js
+++ b/src/validators/isDateAfter.spec.js
@@ -1,4 +1,4 @@
-import isDateAfter from './isDateAfter';
+import { isDateAfter } from '../';
 
 describe('isDateAfter', () => {
   const someFields = {};

--- a/src/validators/isDateInPast.spec.js
+++ b/src/validators/isDateInPast.spec.js
@@ -1,5 +1,5 @@
 import mockdate from 'mockdate';
-import isDateInPast from './isDateInPast';
+import { isDateInPast } from '../';
 
 describe('isDateInPast', () => {
   const someFields = {};

--- a/src/validators/isDateOnOrAfter.spec.js
+++ b/src/validators/isDateOnOrAfter.spec.js
@@ -1,4 +1,4 @@
-import isDateOnOrAfter from './isDateOnOrAfter';
+import { isDateOnOrAfter } from '../';
 
 describe('isDateOnOrAfter', () => {
   const someFields = {};

--- a/src/validators/isEmail.spec.js
+++ b/src/validators/isEmail.spec.js
@@ -1,4 +1,4 @@
-import isEmail from './isEmail';
+import { isEmail } from '../';
 
 describe('isEmail', () => {
   const someFields = {};

--- a/src/validators/isPresent.spec.js
+++ b/src/validators/isPresent.spec.js
@@ -1,4 +1,4 @@
-import isPresent from './isPresent';
+import { isPresent } from '../';
 
 describe('isPresent', () => {
   const someFields = {};

--- a/src/validators/isZipCode.spec.js
+++ b/src/validators/isZipCode.spec.js
@@ -1,4 +1,4 @@
-import isZipCode from './isZipCode';
+import { isZipCode } from '../';
 
 describe('isZipCode', () => {
   const someFields = {};


### PR DESCRIPTION
Adds export for `isDateOnOrAfter` to main `index.js` file.
Updates all validator specs to import from `index.js` as opposed to individual validator files per the comment in [PR 8](https://github.com/policygenius/redux-form-validations/pull/8). This should help guard against omitting new validators from `index.js`.

TODO:

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests pass
- [X] Update CHANGELOG.md with your change
