### PR TITLE
Invalidate emails with spaces in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### v NEXT
 
+### v 0.1.4
+- Invalidate emails with spaces in them by [Trevor Nelson](https://github.com/trevornelson) in [#23](https://github.com/policygenius/redux-form-validations/pull/23)
+
 ### v 0.1.3
 - Add `isPhoneNumber` validator by [Sunny Mistry](https://github.com/sunnymis) in [#22](https://github.com/policygenius/redux-form-validations/pull/22)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-validations",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Validation utilities for redux-form v6",
   "author": "PolicyGenius",
   "license": "MIT",

--- a/src/validators/isEmail.js
+++ b/src/validators/isEmail.js
@@ -4,7 +4,7 @@ import { isEmpty } from '../helpers';
 
 /* eslint-disable max-len */
 /* eslint-disable no-useless-escape */
-const EMAIL_REGEX = /.+@.+\..+/;
+const EMAIL_REGEX = /^\S+@\S+\.\S+/;
 /* eslint-disable */
 
 export default {

--- a/src/validators/isEmail.spec.js
+++ b/src/validators/isEmail.spec.js
@@ -8,9 +8,21 @@ describe('isEmail', () => {
       expect(isEmail.validator(someFields, 'asdf@fakemail.com')).toBe(true);
     });
 
-    context('when the value is not a valid email address', () => {
+    context('when the value has no domain', () => {
       it('returns false', () => {
         expect(isEmail.validator(someFields, 'asdffakemail.com')).toBe(false);
+      });
+    });
+
+    context('when the value has no TLD', () => {
+      it('returns false', () => {
+        expect(isEmail.validator(someFields, 'asdffakemail@email')).toBe(false);
+      });
+    });
+
+    context('when the value has a space in it', () => {
+      it('returns false', () => {
+        expect(isEmail.validator(someFields, 'asdf fakemail@email.com')).toBe(false);
       });
     });
 


### PR DESCRIPTION
A previous PR allowed for spaces in an email address. Loosening the regex to account for new TLDs like `.photography` or `.nyc` made sense in #16 , but even a loose email validator should invalidate email addresses with spaces in them. 

<!--
  Thanks for filing a pull request on redux-form-validations!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the public API, update the README
